### PR TITLE
Check if mount actually exist before umount

### DIFF
--- a/builds/installer/installer.sh
+++ b/builds/installer/installer.sh
@@ -162,9 +162,9 @@ installer_partition_format() {
 
 installer_umount_blockdev() { 
     local blockdev=$1
-    grep $1 /proc/mounts
+    grep $blockdev /proc/mounts
     if [ 0 = $? ]; then
-        umount `cat /proc/mounts | grep ${blockdev} | awk '{print $2}'` || true
+        umount `awk "/${blockdev}/ "'{print $2}' /proc/mounts` || true
     else
         echo $1 not mounted, skiping umount
         exit 1


### PR DESCRIPTION
So I've tired of looking at help of umount during ONL install, because it running w/o arguments, no mount found in /proc/mounts, so I've added check to skip umount and give some debug info.

Also what reasoning running cat and then grep, why not just run this code? Seems wasteful unless you are grep two or more files at once. But leaving as it is for now, if I miss some magic here :)

```
umount `grep ${blockdev} /proc/mounts | awk '{print $2}'` || true
```
