### PR TITLE
unknown operand installer fix

### DIFF
--- a/builds/installer/installer.sh
+++ b/builds/installer/installer.sh
@@ -167,7 +167,7 @@ installer_umount_blockdev() {
         blockdev=NONEXISTANT
     fi
 
-    if [ grep $blockdev /proc/mounts ]; then
+    if grep -q $blockdev /proc/mounts; then
         umount `cat /proc/mounts | grep ${blockdev} | awk '{print $2}'` || true
     else
         echo $1 not mounted, skipping umount
@@ -389,7 +389,7 @@ cd $(dirname $0)
 # Check installer debug option from the uboot environment
 fw_printenv onl_installer_debug &> /dev/null && installer_debug=1
 # Check installer verbose option from the environment set by ONIE
-[ $onie_verbose = 'y' ] && installer_debug=1
+[ -n "$onie_verbose" ] && [ $onie_verbose = 'y' ] && installer_debug=1
 
 if [ "$installer_debug" ]; then
     echo "Debug mode"


### PR DESCRIPTION
Fix errors durring install `sh: y: unknown operand`, `sh: sda: unknown operand` and checks if $onie_verbose variable exist.

Check #53 for discussion 