### PR TITLE
Made platform-baseconf update the .so not the .so.1

### DIFF
--- a/builds/swi/all/shared/etc/init.d/platform-baseconf
+++ b/builds/swi/all/shared/etc/init.d/platform-baseconf
@@ -37,7 +37,7 @@ if DEB_GNU_HOST_TYPE is None:
     sys.stderr.write("Could not determine the current host type.\n")
     sys.exit(1)
 
-DEFAULT_ONLP_LIB = "/lib/%s/libonlp-platform.so.1" % DEB_GNU_HOST_TYPE
+DEFAULT_ONLP_LIB = "/lib/%s/libonlp-platform.so" % DEB_GNU_HOST_TYPE
 PLATFORM_ONLP_LIB = "%s/lib/libonlp-%s.so" % (platform.platform_basedir(), platform.platform())
 
 if os.path.exists(PLATFORM_ONLP_LIB):


### PR DESCRIPTION
Fixes issue with ldconfig overwriting our platform libraries

Reviewer: @jnealtowns 