### PR TITLE
Initialize platform-baseconfig before snmpd

### DIFF
--- a/builds/swi/amd64/kvm/rootfs/cleanup
+++ b/builds/swi/amd64/kvm/rootfs/cleanup
@@ -32,8 +32,8 @@ chroot "${WS_ROOT}" /usr/sbin/update-rc.d initdev defaults
 chroot "${WS_ROOT}" /usr/sbin/update-rc.d restorepersist defaults
 chroot "${WS_ROOT}" /usr/sbin/update-rc.d rc.boot defaults
 chroot "${WS_ROOT}" /usr/sbin/update-rc.d sensors-baseconf defaults
-chroot "${WS_ROOT}" /usr/sbin/update-rc.d snmpd-baseconf defaults
 chroot "${WS_ROOT}" /usr/sbin/update-rc.d platform-baseconf defaults
+chroot "${WS_ROOT}" /usr/sbin/update-rc.d snmpd-baseconf defaults
 chroot "${WS_ROOT}" /usr/sbin/update-rc.d loadstartupconfig defaults
 chroot "${WS_ROOT}" /usr/sbin/update-rc.d snmpd remove
 chroot "${WS_ROOT}" /usr/sbin/update-rc.d ssh defaults


### PR DESCRIPTION
Because snmpd depends on platform-baseconfig; only affects amd64/kvm build.

Fixes autobuild.sh problems.

Reviewer: @jnealtowns 