### PR TITLE
Added onlp-x86-64-accton-as6712-32x-r0:amd64 to CLOSED_SOURCE exceptions

### DIFF
--- a/tools/onlpkg.py
+++ b/tools/onlpkg.py
@@ -53,6 +53,7 @@ closed_source = [
 "onlp-powerpc-accton-as5710-54x-r0:powerpc",
 "onlp-powerpc-accton-as4600-54t-r0:powerpc",
 "onlp-x86-64-accton-as5712-54x-r0:amd64",
+"onlp-x86-64-accton-as6712-32x-r0:amd64"
 "onlp-powerpc-dni-7448-r0:powerpc",
 ];
 


### PR DESCRIPTION
Don't try to build it unless ONL_CLOSED_SOURCE is set

Reviewer: @jnealtowns 