### PR TITLE
initrd-amd64: Allow tty assigned with linux cmdline for amd64 platform

### DIFF
--- a/builds/swi/all/shared/sbin/pgetty
+++ b/builds/swi/all/shared/sbin/pgetty
@@ -1,6 +1,12 @@
 #!/bin/sh
 
 t=/dev/$1
+# if $1 is not set, use linux cmdline console as default tty
+[ -z "$1" ] && {
+	tty=$(/bin/sed 's/.*console=\([^,]*\).*/\1/' /proc/cmdline)
+	>&2 echo Connecting tty=$tty with $0
+	t=/dev/$tty
+}
 
 # Reset the console tty to standard settings
 /bin/stty -F $t sane pass8 -ixon -cstopb clocal

--- a/builds/swi/amd64/all/rootfs/cleanup
+++ b/builds/swi/amd64/all/rootfs/cleanup
@@ -61,7 +61,7 @@ ${RFSTOOL} -c user_admin_add
 
 rm -f "${WS_ROOT}/etc/securetty" # allow root login via telnet
 sed -i "s/\(^[123456]:.*\)/#\1/" "${WS_ROOT}/etc/inittab"
-echo "T0:23:respawn:/sbin/pgetty ttyS0" >>"${WS_ROOT}/etc/inittab"
+echo "T0:23:respawn:/sbin/pgetty" >>"${WS_ROOT}/etc/inittab"
 
 echo "onl-powerpc" > "${WS_ROOT}/etc/hostname"
 


### PR DESCRIPTION
As x86_64 cpu may use another serial port as tty, using ttyS0 or ttyS1 should be found with linux cmdline