### PR TITLE
Accton AS5712_54X: revise console port config in grub.cfg

### DIFF
--- a/components/all/platform-config/x86-64-accton-as5712-54x-r0/src/boot/grub.cfg
+++ b/components/all/platform-config/x86-64-accton-as5712-54x-r0/src/boot/grub.cfg
@@ -1,4 +1,4 @@
-serial --port=0x3f8 --speed=115200 --word=8 --parity=no --stop=1
+serial --port=0x2f8 --speed=115200 --word=8 --parity=no --stop=1
 terminal_input serial
 terminal_output serial
 set timeout=5
@@ -9,7 +9,7 @@ menuentry OpenNetworkLinux {
   echo 'Loading Open Network Linux ...'
   insmod gzio
   insmod part_msdos
-  linux /kernel-3.14-x86_64-all nopat console=ttyS0,115200n8 onl_platform=x86-64-accton-as5712-54x-r0
+  linux /kernel-3.14-x86_64-all nopat console=ttyS1,115200n8 onl_platform=x86-64-accton-as5712-54x-r0
   initrd /initrd-amd64
 }
 


### PR DESCRIPTION
To fix the issue that console gets no message output.