### PR TITLE
Ofdpa closed fix

### DIFF
--- a/components/any/ofdpa-2.0-closed/Makefile
+++ b/components/any/ofdpa-2.0-closed/Makefile
@@ -7,9 +7,10 @@ endif
 
 # if we have access to the closed source, then check it out
 ifdef $(ONL_CLOSED_SOURCE)
-ONL_REQUIRED_SUBMODULES := ofdpa-2.0-closed
+ONL_REQUIRED_SUBMODULES := infra bigcode ofdpa-2.0-closed
 ONL_REQUIRED_PACKAGES := kernel-85xx-headers:powerpc
-# else nothing
+else
+ONL_REQUIRED_SUBMODULES := infra bigcode
 endif
 
 include $(ONL)/make/component.mk

--- a/components/any/ofdpa-2.0-closed/Makefile
+++ b/components/any/ofdpa-2.0-closed/Makefile
@@ -5,8 +5,11 @@ ifndef ARCH
 $(error $$ARCH is undefined.)
 endif
 
+# if we have access to the closed source, then check it out
+ifdef $(ONL_CLOSED_SOURCE)
 ONL_REQUIRED_SUBMODULES := ofdpa-2.0-closed
-#ONL_REQUIRED_PACKAGES := onlp-platform:$(ARCH) onlp-platform-defaults:$(ARCH)
 ONL_REQUIRED_PACKAGES := kernel-85xx-headers:powerpc
+# else nothing
+endif
 
 include $(ONL)/make/component.mk

--- a/components/any/ofdpa-2.0-closed/Makefile.comp
+++ b/components/any/ofdpa-2.0-closed/Makefile.comp
@@ -45,6 +45,7 @@ ifndef $(ONL_CLOSED_SOURCE)
 RELEASE=$(shell cat deb/debuild/debian/changelog  | grep ^ofdpa-2.0-closed | head -1 | tr -d '/()/' | cut -f2 -d\ )
 deb: 
 	echo ONL_CLOSED_SOURCE not set- Downloading ofdpa-2.0-closed v=$(RELEASE) from apt.opennetlinux.org
+	mkdir -p $(ONL_REPO)/$(ARCH)
 	cd $(ONL_REPO)/$(ARCH) && wget  http://opennetlinux.org/debian/dists/unstable/main/binary-powerpc/ofdpa-2.0-closed_$(RELEASE)_powerpc.deb
 else
 deb: ofdpa-2.0-closed


### PR DESCRIPTION
Fixing the hoops to jump through to disable the build system and download the ofdpa-2.0-closed package if you don't have access to the NDA'd source code.