### PR TITLE
Changed docker environment to build as non-root

### DIFF
--- a/tools/docker/Makefile
+++ b/tools/docker/Makefile
@@ -6,7 +6,7 @@ ifndef ONL
 $(error Need to define $$ONL variable to use this Makefile)
 endif
 
-IMAGE=1.5
+IMAGE=1.6
 
 
 # needed to get SSH agent credential forwarding
@@ -30,12 +30,14 @@ docker_run: docker_check
 	$(DOCKER) run --privileged -t -i \
         -e USER=root \
         -e ONL=$(ONL) \
+        -e MAKE_UID=`id -u` \
+        -e MAKE_USER=$(USER) \
         -v $(ONL):$(ONL) \
         -w $(ONL) $(DNS) \
         -h "onl-builder" \
         $(SSH_AGENT) \
         opennetworklinux/onl-build:$(IMAGE) \
-        bash -c '/etc/init.d/apt-cacher-ng start && bash'
+        bash -c '$(ONL)/tools/docker/docker_shell.sh'
 
 # DANGER - destructively kills all containers and images - DO NOT USE
 docker_nuke_all: docker_check

--- a/tools/docker/docker_shell.sh
+++ b/tools/docker/docker_shell.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# This is the list of things to run when starting docker
+
+# Start the local apt caching daemon
+/etc/init.d/apt-cacher-ng start
+
+# Create an account with the calling UID and add it to sudo
+if [ ! -z $MAKE_USER ] ; then
+    useradd $MAKE_USER --uid $MAKE_UID
+    echo "$MAKE_USER     ALL=(ALL:ALL) NOPASSWD:ALL" >> /etc/sudoers
+    exec sudo -u $MAKE_USER -s
+else
+    exec bash
+fi
+


### PR DESCRIPTION
Created docker_shell.sh script to create the local user
in the docker environment on the fly.

This solves annoying permissions problems for dynamically created files being owned by root.


FYI @jnealtowns @sonoble 