### PR TITLE
add onlp env. for accton as7512-32x/as7712-32x

### DIFF
--- a/builds/swi/amd64/all/rootfs/repo.amd64
+++ b/builds/swi/amd64/all/rootfs/repo.amd64
@@ -1,5 +1,5 @@
 [deb-amd64]
-packages=gawk snmpd lm-sensors fancontrol pciutils usbutils mtd-utils kexec-tools i2c-tools module-init-tools isc-dhcp-client ntp wget ethtool localepurge tcpdump telnetd python-pyinotify cpio util-linux dosfstools gnu-fdisk rssh u-boot-tools file gdb binutils faultd onlp onlp-platform onlp-platform-defaults onlp-x86-64-dell-s6000-s1220-r0 onlp-x86-64-dell-s4000-c2338-r0 onlp-x86-64-accton-as5712-54x-r0 onlp-x86-64-accton-as6712-32x-r0 orc dmidecode
+packages=gawk snmpd lm-sensors fancontrol pciutils usbutils mtd-utils kexec-tools i2c-tools module-init-tools isc-dhcp-client ntp wget ethtool localepurge tcpdump telnetd python-pyinotify cpio util-linux dosfstools gnu-fdisk rssh u-boot-tools file gdb binutils faultd onlp onlp-platform onlp-platform-defaults onlp-x86-64-dell-s6000-s1220-r0 onlp-x86-64-dell-s4000-c2338-r0 onlp-x86-64-accton-as5712-54x-r0 onlp-x86-64-accton-as6712-32x-r0 onlp-x86-64-accton-as7512-32x-r0 onlp-x86-64-accton-as7712-32x-r0 orc dmidecode
 source=copy:__DIR__/amd64/ ./
 omitdebsrc=true
 

--- a/tools/onlpkg.py
+++ b/tools/onlpkg.py
@@ -57,6 +57,8 @@ closed_source = [
 "onlp-powerpc-accton-as4600-54t-r0:powerpc",
 "onlp-x86-64-accton-as5712-54x-r0:amd64",
 "onlp-x86-64-accton-as6712-32x-r0:amd64",
+"onlp-x86-64-accton-as7512-32x-r0:amd64",
+"onlp-x86-64-accton-as7712-32x-r0:amd64",
 "onlp-powerpc-dni-7448-r0:powerpc"
 ];
 


### PR DESCRIPTION
Before merge this item, it is necessary to public onlp-accton, otherwise building ONL will appear error as below.
===============================================
root@onl-builder:/home/bhu/bigswitch/ONL# make onl-x86
export ONL=`pwd` && make -C $ONL/builds/components
make[1]: Entering directory `/home/bhu/bigswitch/ONL/builds/components'
WARNING:onlpkg:no matching packages for onlp-x86-64-accton-as7512-32x-r0 (amd64)
INFO:onlpkg:found at /home/bhu/bigswitch/ONL/components/amd64/onlp/onlp-x86-64-accton-as7512-32x-r0/deb/debuild/debian
INFO:onlpkg:can be built locally at /home/bhu/bigswitch/ONL/components/amd64/onlp/onlp-x86-64-accton-as7512-32x-r0
make[2]: Entering directory `/home/bhu/bigswitch/ONL/components/amd64/onlp/onlp-x86-64-accton-as7512-32x-r0'
Submodule 'submodules/onlp-accton' (git@github.com:opennetworklinux/onlp-accton) registered for path 'submodules/onlp-accton'
Cloning into 'submodules/onlp-accton'...
The authenticity of host 'github.com (192.30.252.128)' can't be established.
RSA key fingerprint is 16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added 'github.com,192.30.252.128' (RSA) to the list of known hosts.
Permission denied (publickey).
fatal: The remote end hung up unexpectedly
Clone of 'git@github.com:opennetworklinux/onlp-accton' into submodule path 'submodules/onlp-accton' failed
===============================================